### PR TITLE
Add requirement file for python packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.2
+SQLAlchemy==2.0.27
+Flask-CORS==4.0.0
+Flask-SocketIO==5.3.6


### PR DESCRIPTION
Added `requirements.txt` file to include the required python packages as follows

- Flask
- SQLAlchemy
- Flask-CORS
- Flask-SocketIO